### PR TITLE
improved keymaps detection

### DIFF
--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -6,6 +6,7 @@ local function check_map(keymap)
 
   if  keymap.mode ~= "n" and keymap.mode ~= "i"
   and keymap.mode ~= "x" and keymap.mode ~= "v"
+  and keymap.mode ~= "t"
   then
     return false
   end

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -2,20 +2,22 @@
 ---@return table
 
 local function check_map(keymap)
-  -- check if the mapping is one we want to include
+	-- check if the mapping is one we want to include
 
-  if  keymap.mode ~= "n" and keymap.mode ~= "i"
-  and keymap.mode ~= "x" and keymap.mode ~= "v"
-  and keymap.mode ~= "t"
-  then
-    return false
-  end
-  if string.find(keymap.lhs, "<Plug>")
-    then
-      return false
-  end
+	if
+		keymap.mode ~= "n"
+		and keymap.mode ~= "i"
+		and keymap.mode ~= "x"
+		and keymap.mode ~= "v"
+		and keymap.mode ~= "t"
+	then
+		return false
+	end
+	if string.find(keymap.lhs, "<Plug>") then
+		return false
+	end
 
-  return true
+	return true
 end
 
 return function()
@@ -31,20 +33,20 @@ return function()
 			-- HACK: can't encode a function
 			-- but we should probably write out what it does
 			map.rhs = "<function>"
-    elseif map.rhs == "" then
+		elseif map.rhs == "" then
 			-- replace the empty string with empty modifier
 			map.rhs = "<Nop>"
 		end
 
-    if check_map(map) then
-      table.insert(keymaps, {
-        mode = map.mode,
-        lhs = map.lhs,
-        rhs = map.rhs,
-        desc = map.desc == nil and "" or map.desc,
-        noremap = map.noremap == 1,
-      })
-    end
+		if check_map(map) then
+			table.insert(keymaps, {
+				mode = map.mode,
+				lhs = map.lhs,
+				rhs = map.rhs,
+				desc = map.desc == nil and "" or map.desc,
+				noremap = map.noremap == 1,
+			})
+		end
 	end
 
 	return keymaps

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -23,7 +23,7 @@ return function()
 
 	for _, map in pairs(global_keymaps) do
 		-- translate the strings into something usable by :map
-		map.lhs = vim.api.nvim_replace_termcodes(map.lhs, true, true, false)
+		map.lhs = vim.fn.maparg(map.lhs, map.mode, false, true).lhs
 
 		if map.callback then
 			-- check if the mapping is a function

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -8,16 +8,14 @@ return function()
 		-- translate the strings into something usable by :map
 		map.lhs = vim.api.nvim_replace_termcodes(map.lhs, true, true, false)
 
-		if map.rhs == "" then
-			-- replace the empty string with empty modifier
-			map.rhs = "<Nop>"
-		end
-
 		if map.callback then
 			-- check if the mapping is a function
 			-- HACK: can't encode a function
 			-- but we should probably write out what it does
-			map.callback = "function"
+			map.rhs = "<function>"
+    elseif map.rhs == "" then
+			-- replace the empty string with empty modifier
+			map.rhs = "<Nop>"
 		end
 
 		table.insert(keymaps, {

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -3,8 +3,12 @@
 
 local function check_map(keymap)
   -- check if the mapping is one we want to include
-  -- TODO: check for more than just <Plug>
 
+  if  keymap.mode ~= "n" and keymap.mode ~= "i"
+  and keymap.mode ~= "x" and keymap.mode ~= "v"
+  then
+    return false
+  end
   if string.find(keymap.lhs, "<Plug>")
     then
       return false

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -1,5 +1,18 @@
 ---Get all user defined keymaps
 ---@return table
+
+local function check_map(keymap)
+  -- check if the mapping is one we want to include
+  -- TODO: check for more than just <Plug>
+
+  if string.find(keymap.lhs, "<Plug>")
+    then
+      return false
+  end
+
+  return true
+end
+
 return function()
 	local keymaps = {}
 	local global_keymaps = vim.api.nvim_get_keymap("")
@@ -18,13 +31,15 @@ return function()
 			map.rhs = "<Nop>"
 		end
 
-		table.insert(keymaps, {
-			mode = map.mode,
-			lhs = map.lhs,
-			rhs = map.rhs,
-			desc = map.desc == nil and "" or map.desc,
-			noremap = map.noremap == 1,
-		})
+    if check_map(map) then
+      table.insert(keymaps, {
+        mode = map.mode,
+        lhs = map.lhs,
+        rhs = map.rhs,
+        desc = map.desc == nil and "" or map.desc,
+        noremap = map.noremap == 1,
+      })
+    end
 	end
 
 	return keymaps

--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -23,7 +23,7 @@ return function()
 
 	for _, map in pairs(global_keymaps) do
 		-- translate the strings into something usable by :map
-		map.lhs = vim.fn.maparg(map.lhs, map.mode, false, true).lhs
+		map.lhs = vim.fn.maparg(map.lhsraw, map.mode, false, true).lhs
 
 		if map.callback then
 			-- check if the mapping is a function


### PR DESCRIPTION
- [x] set callback to rhs when applicable
- [x] filter out \<plug\> mappings
- [x] limit type of keymaps checked, #2 
- [x] move from `nvim_replace_termcodes` to `vim.fn.maparg(..).lhs`