### PR TITLE
fix(keymaps): revert use of lhsraw for maparg

### DIFF
--- a/lua/dotfyle_metadata/keymaps.lua
+++ b/lua/dotfyle_metadata/keymaps.lua
@@ -26,7 +26,7 @@ return function()
 
 	for _, map in pairs(global_keymaps) do
 		-- translate the strings into something usable by :map
-		map.lhs = vim.fn.maparg(map.lhsraw, map.mode, false, true).lhs
+		map.lhs = vim.fn.maparg(map.lhs, map.mode, false, true).lhs
 
 		if map.callback then
 			-- check if the mapping is a function


### PR DESCRIPTION
The output from lhsraw gives the escape codes for some keys (e.g. \t instead of <tab>) which doesn't work when looking up in `mapargs()`. This then set that keymap to nil and went on to cause a crash.
This pr just reverts that change