### PR TITLE
fix: use lspconfig.util._available_servers

### DIFF
--- a/lua/dotfyle_metadata/extras/lsp.lua
+++ b/lua/dotfyle_metadata/extras/lsp.lua
@@ -7,7 +7,13 @@ return function()
 		return {}
 	end
 
-	local servers = lspconfig.util.available_servers()
+	local servers
+
+	if lspconfig.util._available_servers ~= nil then
+		servers = lspconfig.util._available_servers()
+	else
+		servers = lspconfig.util.available_servers()
+	end
 
 	-- sort the plugins A-Za-z
 	table.sort(servers)


### PR DESCRIPTION
The `lspconfig.util.available_servers` has become a private function and it no longer works. 
This PR will fix this.

ref: https://github.com/neovim/nvim-lspconfig/commit/e118ce58dab72c17216292eef7df4cee3cf60885
ref: https://github.com/folke/neoconf.nvim/pull/105